### PR TITLE
build flake internal tools using internal toolchain

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,13 +24,14 @@
   outputs = inputs:
 
     let
-      buildWorkspace = args@{ pkgs, crane, src, ... }:
+      mkRustTarget = pkgs: pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+      buildWorkspace = args@{ pkgs, crane, src, craneInternal ? (crane.overrideToolchain (mkRustTarget pkgs)), ... }:
         (import ./lib {
-          inherit pkgs crane;
+          inherit pkgs crane craneInternal;
           nix-filter = inputs.nix-filter;
         }) {
           inherit src;
-          args = (builtins.removeAttrs args [ "pkgs" "src" "crane" ]);
+          args = (builtins.removeAttrs args [ "pkgs" "src" "crane" "craneInternal" ]);
         };
     in
     { inherit buildWorkspace; } // inputs.flake-utils.lib.eachDefaultSystem (system:

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -1,10 +1,10 @@
-{ pkgs, crane, nix-filter }:
+{ pkgs, crane, craneInternal, nix-filter }:
 
 let
   # Handler crate
   callPackage = pkgs.lib.callPackageWith (pkgs // packages // { inherit nix-filter crane; });
   packages = {
-    extractMetadata = crane.buildPackage {
+    extractMetadata = craneInternal.buildPackage {
       src = ../extract_metadata;
     };
     workspaceMetadata = callPackage ./workspaceMetadata.nix { };


### PR DESCRIPTION
I'm building a workspace with a rust toolchain at version 1.67.0, and the extract_metadata crate requires rust 1.70.0. This change allows for workspaces with a lower MSRV than the extract_metadata crate.