### PR TITLE
get cargo target from nix args

### DIFF
--- a/extract_metadata/src/main.rs
+++ b/extract_metadata/src/main.rs
@@ -19,13 +19,14 @@ struct Args {
 
 fn main() {
     let args = Args::parse();
+
+    let feature_sets = get_feature_sets(&args.target_platform);
+
     let metadata = MetadataCommand::new()
         .manifest_path(args.manifest_path)
         .other_options(["--filter-platform".to_string(), args.target_platform])
         .exec()
         .unwrap();
-
-    let feature_sets = get_feature_sets();
 
     let wmi = WorkspaceMetadataInfo::from_metadata(metadata, feature_sets);
 
@@ -34,7 +35,7 @@ fn main() {
 
 /// cargo tree -f '{p}|{f}' --prefix none --target x86_64-unknown-linux-gnu
 
-fn get_feature_sets() -> HashMap<(String, String), Vec<String>> {
+fn get_feature_sets(target_platform: &str) -> HashMap<(String, String), Vec<String>> {
     let mut cargo_tree = Command::new("cargo");
     cargo_tree.args([
         "tree",
@@ -43,7 +44,7 @@ fn get_feature_sets() -> HashMap<(String, String), Vec<String>> {
         "--prefix",
         "none",
         "--target",
-        "x86_64-unknown-linux-gnu",
+        target_platform
     ]);
 
     cargo_tree.stdin(Stdio::null());

--- a/lib/buildWorkspace.nix
+++ b/lib/buildWorkspace.nix
@@ -13,7 +13,7 @@ let
       echo "Erased all dev-deps"
     '';
   };
-  rawMetadata = workspaceMetadata globalDummy;
+  rawMetadata = workspaceMetadata globalDummy (args.CARGO_BUILD_TARGET or "x86_64-unknown-linux-gnu");
   metadata = builtins.fromTOML (builtins.readFile rawMetadata);
   get_dependencies_for = name: rawMetadata: pkgs.runCommandLocal "deps.toml" { buildInputs = [ pkgs.dasel ]; } ''
     dasel -r toml -f ${rawMetadata} 'workspace_member_info.${name}.dependencies' > $out

--- a/lib/workspaceMetadata.nix
+++ b/lib/workspaceMetadata.nix
@@ -1,9 +1,9 @@
 { pkgs, crane, extractMetadata }:
-dummySrc: crane.mkCargoDerivation {
+dummySrc: buildTarget: crane.mkCargoDerivation {
   cargoArtifacts = null;
   nativeBuildInputs = [ extractMetadata ];
   buildPhaseCargoCommand = ''
-    extract_metadata Cargo.toml x86_64-unknown-linux-gnu > $out
+    extract_metadata Cargo.toml ${buildTarget} > $out
   '';
 
   src = dummySrc;


### PR DESCRIPTION
if some targets enable different features than others using [platform specific dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#platform-specific-dependencies) then feature extraction is broken and the workspace-deps build won't apply the correct features intended!

The way I'm currently selecting the target I'm building for is by adding a `CARGO_BUILD_TARGET` attribute that will set an environment variable in the ultimate `mkDerivation` that calls cargo, so that is all this PR supports. This might be the more "nix"-ey way to do it, but users may also do this by adding a `--target <triple>` to `cargoExtraArgs` which will be harder to parse out in pure nix, but maybe we can add a trace warning